### PR TITLE
Use react ref to manage plugin state

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For more information about what keys can be passed into the `data` key in the `m
 
 ```jsx
 import app from './package.json' // this is your application's package.json
-import Video from 'react-native-video'; // import Video from react-native-video like your normally would
+import Video from 'react-native-video'; // import Video from react-native-video like you normally would
 import muxReactNativeVideo from 'mux-react-native-video-sdk';
 
 // wrap the `Video` component with Mux functionality

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mux-react-native-video-sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for react-native-video",
   "homepage": "https://github.com/muxinc/mux-stats-sdk-react-native-video",


### PR DESCRIPTION
https://app.shortcut.com/websdks/story/10567/fix-null-playerid-s-in-mux-react-native-video-sdk
https://app.shortcut.com/mux/story/10454/errors-when-using-mux-react-native-video-sdk-with-react-native-video-controls

This stemmed from an issue we had where we were emitting events but with a `null` playerID. We would get a `null` playerID when trying to clean up a player from a global state object. But we really don't need a global state object when we can use `React.useRef`. That allows us to update internal state without causing rerenders, which is probably what we want anyway.

