### PR TITLE
Add empty TypeScript module declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@mux/mux-data-react-native-video'


### PR DESCRIPTION
Installing this package in a TypeScript project that has `"strict": true` enabled leads to the following type error.

> Could not find a declaration file for module '@mux/mux-data-react-native-video'.
> 'react-native-mux.js' implicitly has an 'any' type.

Fixing this error adds a few minutes of work to the task of integrating the SDK. We can eliminate that work by including this file in the repository.
